### PR TITLE
Natural light dimming

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -230,7 +230,7 @@ class HomeAssistantSkill(FallbackSkill):
             self.speak_dialog('homeassistant.error.sorry')
             return
 
-    @intent_file_handler('set.light.brightness.intent')
+    # @intent_file_handler('set.light.brightness.intent')
     def handle_light_set_intent(self, message):
         entity = message.data["entity"]
         try:

--- a/__init__.py
+++ b/__init__.py
@@ -255,10 +255,10 @@ class HomeAssistantSkill(FallbackSkill):
 
         ha_data['brightness'] = brightness_value
 
-        dg_data = {'brightness_percentage' = brightness_percentage}
+        dg_data = {'brightness_percentage': brightness_percentage}
         dg_data['dev_name'] = ha_entity['dev_name']
 
-        self.ha.execute_service("light", "turn_on", {"entity_id": ha_data['entity_id'], "brightness": ha_data['brightness']})
+        self.ha.execute_service("light", "turn_on", ha_data)
         self.speak_dialog('homeassistant.brightness.dimmed',
                           data=dg_data)
 

--- a/__init__.py
+++ b/__init__.py
@@ -254,9 +254,13 @@ class HomeAssistantSkill(FallbackSkill):
         # self.set_context('Entity', ha_entity['dev_name'])
 
         ha_data['brightness'] = brightness_value
+
+        dg_data = {'brightness_percentage' = brightness_percentage}
+        dg_data['dev_name'] = ha_entity['dev_name']
+
         self.ha.execute_service("light", "turn_on", ha_data)
         self.speak_dialog('homeassistant.brightness.dimmed',
-                          data=ha_data)
+                          data=dg_data)
 
         return
 

--- a/__init__.py
+++ b/__init__.py
@@ -254,7 +254,6 @@ class HomeAssistantSkill(FallbackSkill):
         # self.set_context('Entity', ha_entity['dev_name'])
 
         ha_data['brightness'] = brightness_value
-        ha_data['dev_name'] = ha_entity['dev_name']
         self.ha.execute_service("light", "turn_on", ha_data)
         self.speak_dialog('homeassistant.brightness.dimmed',
                           data=ha_data)

--- a/__init__.py
+++ b/__init__.py
@@ -80,7 +80,7 @@ class HomeAssistantSkill(FallbackSkill):
         self.load_vocab_files(join(dirname(__file__), 'vocab', self.lang))
         self.load_regex_files(join(dirname(__file__), 'regex', self.lang))
         self.__build_switch_intent()
-        self.__build_light_adjust_intent()
+        #self.__build_light_adjust_intent()
         self.__build_automation_intent()
         self.__build_sensor_intent()
         self.__build_tracker_intent()

--- a/__init__.py
+++ b/__init__.py
@@ -254,9 +254,8 @@ class HomeAssistantSkill(FallbackSkill):
         # self.set_context('Entity', ha_entity['dev_name'])
 
         ha_data['brightness'] = brightness_value
-        ha_data['brightness_percentage'] = brightness_percentage
         ha_data['dev_name'] = ha_entity['dev_name']
-        self.ha.execute_service("homeassistant", "turn_on", ha_data)
+        self.ha.execute_service("light", "turn_on", ha_data)
         self.speak_dialog('homeassistant.brightness.dimmed',
                           data=ha_data)
 

--- a/__init__.py
+++ b/__init__.py
@@ -258,7 +258,7 @@ class HomeAssistantSkill(FallbackSkill):
         dg_data = {'brightness_percentage' = brightness_percentage}
         dg_data['dev_name'] = ha_entity['dev_name']
 
-        self.ha.execute_service("light", "turn_on", ha_data)
+        self.ha.execute_service("light", "turn_on", {"entity_id": ha_data['entity_id'], "brightness": ha_data['brightness']})
         self.speak_dialog('homeassistant.brightness.dimmed',
                           data=dg_data)
 

--- a/__init__.py
+++ b/__init__.py
@@ -108,13 +108,13 @@ class HomeAssistantSkill(FallbackSkill):
             "SwitchActionKeyword").require("Action").require("Entity").build()
         self.register_intent(intent, self.handle_switch_intent)
 
-    def __build_light_adjust_intent(self):
-        intent = IntentBuilder("LightAdjBrightnessIntent") \
-            .optionally("LightsKeyword") \
-            .one_of("IncreaseVerb", "DecreaseVerb", "LightBrightenVerb",
-                    "LightDimVerb") \
-            .require("Entity").optionally("BrightnessValue").build()
-        self.register_intent(intent, self.handle_light_adjust_intent)
+    #def __build_light_adjust_intent(self):
+    #    intent = IntentBuilder("LightAdjBrightnessIntent") \
+    #        .optionally("LightsKeyword") \
+    #        .one_of("IncreaseVerb", "DecreaseVerb", "LightBrightenVerb",
+    #                "LightDimVerb") \
+    #        .require("Entity").optionally("BrightnessValue").build()
+    #    self.register_intent(intent, self.handle_light_adjust_intent)
 
     def __build_automation_intent(self):
         intent = IntentBuilder("AutomationIntent").require(
@@ -254,6 +254,7 @@ class HomeAssistantSkill(FallbackSkill):
         # self.set_context('Entity', ha_entity['dev_name'])
 
         ha_data['brightness'] = brightness_value
+        ha_data['brightness_percentage'] = brightness_percentage
         ha_data['dev_name'] = ha_entity['dev_name']
         self.ha.execute_service("homeassistant", "turn_on", ha_data)
         self.speak_dialog('homeassistant.brightness.dimmed',

--- a/dialog/en-us/homeassistant.brightness.dimmed.dialog
+++ b/dialog/en-us/homeassistant.brightness.dimmed.dialog
@@ -1,1 +1,3 @@
-Set the brightness of {{dev_name}} to {{brightness}} percent.
+Dimmed {{dev_name}} to {{brightness_percentage}} percent.
+Set {{dev_name}} to {{brightness_percentage}} percent.
+{{dev_name}} is now set to {{brightness_percentage}} percent.

--- a/vocab/en-us/set.light.brightness.intent
+++ b/vocab/en-us/set.light.brightness.intent
@@ -1,1 +1,5 @@
 set brightness of {{entity}} to {{brightnessvalue}} percent
+dim {{entity}} to {{brightnessvalue}} percent
+set {{entity}} to {{brightnessvalue}} percent
+brighten {{entity}} to {{brightnessvalue}} percent
+{{entity}} to {{brightnessvalue}} percent


### PR DESCRIPTION
Makes light dimming more natural, remove redundant intent processors (holdover from engine transition, by the looks of it), ensures the dimming event only fires once when it's run, and changes the HA api endpoint called for dimming to make it work/more reliable.